### PR TITLE
Update vmware_drs_rule_facts.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_drs_rule_facts.py
@@ -70,6 +70,7 @@ drs_rule_facts:
     sample: {
             "DC0_C0": [
                 {
+                    "rule_affinity": false,
                     "rule_enabled": true,
                     "rule_key": 1,
                     "rule_mandatory": true,
@@ -182,6 +183,7 @@ class VmwareDrsFactManager(PyVmomi):
                     rule_uuid=rule_obj.ruleUuid,
                     rule_vms=[vm.name for vm in rule_obj.vm],
                     rule_type="vm_vm_rule",
+                    rule_affinity=True if isinstance(rule_obj, vim.cluster.AffinityRuleSpec) else False,
                     )
 
     def normalize_vm_host_rule_spec(self, rule_obj=None, cluster_obj=None):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The vmware_drs_rule_facts doesn't send whether the Rule is Affinity or Anti Affinity.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_drs_rule_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
While returning the rule facts added whether the DRS rule is Affinity or Anti Affinity in Boolean.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```